### PR TITLE
Handle environment variables more securely

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       dockerfile: users-api/Dockerfile
     environment:
       DB_USERNAME: "postgres"
-      DB_PASSWORD: "testing"
-      LOAD_DATA: "True"
+      DB_PASSWORD: ${DB_PASSWORD:-dMVZFeBWLOzYRV71} #It is strongly recommended to provide DB_PASSWORD in the environment rather than use this default.
+      LOAD_DATA:
     ports:
       - 8000:8000
     depends_on:
@@ -25,7 +25,7 @@ services:
   db:
     image: postgres
     environment:
-      POSTGRES_PASSWORD: testing
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-dMVZFeBWLOzYRV71}
     ports:
       - 5432:5432
 

--- a/users-api/src/docker-entrypoint.sh
+++ b/users-api/src/docker-entrypoint.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-if [ "$LOAD_DATA" = "True" ]; then
+if [[ "${LOAD_DATA:=True}" == "True" ]]; then
   echo "Loading Data..."
   python load-data.py
 else


### PR DESCRIPTION
This PR does two main things:
- Adds a stronger default password for the database
  - We will also read in `DB_PASSWORD` from the environment. There is a note in the `docker-compose.yml` file that recommends this.
- Fixes the `LOAD_DATA` variable so that it is optional, but defaults to "True" (meaning the users data gets loaded on API startup) 