### PR TITLE
Update dependencies  

### DIFF
--- a/users-api/src/requirements.txt
+++ b/users-api/src/requirements.txt
@@ -1,4 +1,4 @@
-flask==2.2.2
-gunicorn==20.1.0
-psycopg==3.1.4
-psycopg-binary==3.1.4
+flask==3.0.0
+gunicorn==21.2.0
+psycopg==3.1.12
+psycopg-binary==3.1.12

--- a/users-ui/src/requirements.txt
+++ b/users-ui/src/requirements.txt
@@ -1,3 +1,3 @@
-flask==2.2.2
-gunicorn==20.1.0
-requests==2.27.1
+flask==3.0.0
+gunicorn==21.2.0
+requests==2.31.0


### PR DESCRIPTION
The version of Flask we had stopped working when Werkzeug 3.0.0 was released. The latest version of Flask fixes the issue, and while I was here I updated the other dependencies as well.